### PR TITLE
Fixed issue with usb_maxpacket in aziokbd.c for kernel 5.19

### DIFF
--- a/aziokbd.c
+++ b/aziokbd.c
@@ -405,7 +405,7 @@ static int usb_kbd_probe(struct usb_interface *iface,
 		return -ENODEV;
 
 	pipe = usb_rcvintpipe(dev, endpoint->bEndpointAddress);
-	maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+	maxp = usb_maxpacket(dev, pipe);
 	kbd = kzalloc(sizeof(struct usb_kbd), GFP_KERNEL);
 	input_dev = input_allocate_device();
 	if (!kbd || !input_dev)


### PR DESCRIPTION
Fixing error
error: too many arguments to function ‘usb_maxpacket’
  408 |         maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
      |                ^~~~~~~~~~~~~
